### PR TITLE
Add nicer timestamps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "clsx": "^2.1.1",
                 "digraph-js": "^2.2.3",
                 "get-urls": "^12.1.0",
+                "luxon": "^3.5.0",
                 "megalodon": "^10.0.3",
                 "rehype-parse": "^9.0.1",
                 "rehype-sanitize": "^6.0.0",
@@ -28,6 +29,7 @@
                 "url-regex-safe": "^4.0.0"
             },
             "devDependencies": {
+                "@types/luxon": "^3.4.2",
                 "@types/node": "^22.5.5",
                 "@types/url-regex-safe": "^1.0.2",
                 "autoprefixer": "^10.4.20",
@@ -1481,6 +1483,12 @@
                 "@types/unist": "*"
             }
         },
+        "node_modules/@types/luxon": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+            "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+            "dev": true
+        },
         "node_modules/@types/mdast": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2680,6 +2688,14 @@
             "dev": true,
             "dependencies": {
                 "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/luxon": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+            "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/mdast-util-to-hast": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "license": "MIT",
     "devDependencies": {
+        "@types/luxon": "^3.4.2",
         "@types/node": "^22.5.5",
         "@types/url-regex-safe": "^1.0.2",
         "autoprefixer": "^10.4.20",
@@ -30,6 +31,7 @@
         "clsx": "^2.1.1",
         "digraph-js": "^2.2.3",
         "get-urls": "^12.1.0",
+        "luxon": "^3.5.0",
         "megalodon": "^10.0.3",
         "rehype-parse": "^9.0.1",
         "rehype-sanitize": "^6.0.0",

--- a/src/components/post/timestamp.tsx
+++ b/src/components/post/timestamp.tsx
@@ -1,0 +1,51 @@
+import { Component, JSX, splitProps } from "solid-js";
+import { DateTime, FixedOffsetZone, Zone } from "luxon";
+
+type TimestampProvider = (ts: DateTime) => string;
+
+const LocalTz: TimestampProvider = (ts) => {
+    return ts.toLocal().toLocaleString({
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+    });
+};
+
+const InternetTime: TimestampProvider = (ts) => {
+    // beats are relative to UTC+1
+    const beatTz = ts.setZone("UTC+1");
+    const date = beatTz.toLocaleString({
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+    });
+    const timeOfDay = beatTz.hour * 3600 + beatTz.minute * 60 + beatTz.second;
+    const beatTime = (timeOfDay / 86.4).toFixed(2).toString().padStart(6, "0");
+    return `${date} @${beatTime}`;
+};
+
+export interface TimestampProps
+    extends Omit<JSX.HTMLAttributes<HTMLSpanElement>, "title"> {
+    ts: DateTime;
+}
+
+export const Timestamp: Component<TimestampProps> = (props) => {
+    const [, rest] = splitProps(props, ["ts"]);
+    // TODO: support other timestamp providers
+    const tsProvider = LocalTz;
+    const longString = props.ts.toLocaleString({
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+    });
+
+    return (
+        <span title={longString} {...rest}>
+            {tsProvider(props.ts)}
+        </span>
+    );
+};

--- a/src/views/post.tsx
+++ b/src/views/post.tsx
@@ -40,6 +40,8 @@ import { cn } from "~/lib/utils";
 import { Dynamic } from "solid-js/web";
 import { ContentGuard } from "~/components/content-guard";
 import { ImageBox } from "~/components/post/image-box";
+import { Timestamp } from "~/components/post/timestamp";
+import { DateTime } from "luxon";
 
 export type PostWithSharedProps = {
     status: Status;
@@ -118,8 +120,8 @@ const PostUserBar: Component<{
             <A href={userHref} class="text-neutral-500">
                 {status.account.acct}
             </A>
-            <A href={postHref} class="text-neutral-500">
-                {status.created_at}
+            <A href={postHref} class="text-neutral-500 text-xs">
+                <Timestamp ts={DateTime.fromISO(status.created_at)} />
             </A>
             <Show when={shared !== null}>
                 <FaSolidArrowsRotate />


### PR DESCRIPTION
This changes the timestamp to be smaller, and have a more locale- friendly format provided by luxon; e.g. "Jan 1, 1970, 12:00 AM". A longer date is provided by mousing over the timestamp.

Optional Internet Time is working, but can't be hooked up until we have settings.