### PR TITLE
User avatars with reduced motion support

### DIFF
--- a/src/Frame.tsx
+++ b/src/Frame.tsx
@@ -25,6 +25,7 @@ import EditOverlay from "./views/editoverlay";
 import { AuthProviderProps, useAuthContext } from "./lib/auth-context";
 import { useEditOverlayContext } from "./lib/edit-overlay-context";
 import { FaSolidBars } from "solid-icons/fa";
+import { AvatarImage } from "./components/user/avatar";
 
 export const initAppFrameAsync = async (authContext: AuthProviderProps) => {
     try {
@@ -128,16 +129,16 @@ const AppFrame: Component<{ children: JSX.Element }> = (props) => {
                                             <Menubar>
                                                 <MenubarMenu>
                                                     <MenubarTrigger>
-                                                        <img
-                                                            src={
+                                                        <AvatarImage
+                                                            user={
                                                                 authContext
                                                                     .authState
                                                                     .signedIn
                                                                     .accountData
-                                                                    .avatar
                                                             }
-                                                            class="aspect-square h-6 inline sm:mr-2"
-                                                            alt="your avatar"
+                                                            twSize="6"
+                                                            class="inline sm:mr-2"
+                                                            alt="Your avatar"
                                                         />
                                                         <span class="hidden sm:inline overflow-hidden text-ellipsis">
                                                             {`${authContext.authState.signedIn.accountData.username}@${authContext.authState.signedIn.domain}`}

--- a/src/Frame.tsx
+++ b/src/Frame.tsx
@@ -136,7 +136,7 @@ const AppFrame: Component<{ children: JSX.Element }> = (props) => {
                                                                     .signedIn
                                                                     .accountData
                                                             }
-                                                            twSize="6"
+                                                            imgClass="size-6"
                                                             class="inline sm:mr-2"
                                                             alt="Your avatar"
                                                         />

--- a/src/components/user/avatar.tsx
+++ b/src/components/user/avatar.tsx
@@ -1,0 +1,61 @@
+import { A } from "@solidjs/router";
+import { Entity } from "megalodon";
+import { Component, createMemo } from "solid-js";
+import { cn } from "~/lib/utils";
+
+export interface AvatarProps {
+    /** The user the avatar applies to. */
+    user: Entity.Account;
+    /** The size represented in tailwind; e.g., "2" for "size-2". */
+    twSize?: string;
+    /** Additional classes to add to the div element. */
+    class?: string;
+    /** A textual representation of the image.
+     *
+     * @default "Avatar for (display name)"
+     */
+    alt?: string;
+}
+
+/**
+ * Represents a user's avatar in a way that respects prefers-reduced-motion.
+ */
+export const AvatarImage: Component<AvatarProps> = (props) => {
+    const sizeClass = `size-${props.twSize ?? "md"}`;
+    return (
+        <div
+            class={cn(
+                "flex-none rounded-md aspect-square overflow-hidden",
+                sizeClass,
+                props.class
+            )}
+        >
+            <picture>
+                <source
+                    srcset={props.user.avatar_static}
+                    class={sizeClass}
+                    media="(prefers-reduced-motion: reduced)"
+                />
+                <img
+                    src={props.user.avatar}
+                    class={sizeClass}
+                    alt={props.alt ?? `Avatar for ${props.user.display_name}`}
+                />
+            </picture>
+        </div>
+    );
+};
+
+/**
+ * A helper component that wraps {@link AvatarImage} with a link to the user's
+ * profile page.
+ */
+export const AvatarLink: Component<AvatarProps> = (props) => {
+    const profileRoute = `/user/${props.user.acct}`;
+
+    return (
+        <A href={profileRoute}>
+            <AvatarImage {...props} />
+        </A>
+    );
+};

--- a/src/components/user/avatar.tsx
+++ b/src/components/user/avatar.tsx
@@ -6,8 +6,8 @@ import { cn } from "~/lib/utils";
 export interface AvatarProps {
     /** The user the avatar applies to. */
     user: Entity.Account;
-    /** The size represented in tailwind; e.g., "2" for "size-2". */
-    twSize?: string;
+    /** Classes to be added directly to the image sources. */
+    imgClass?: string;
     /** Additional classes to add to the div element. */
     class?: string;
     /** A textual representation of the image.
@@ -21,24 +21,23 @@ export interface AvatarProps {
  * Represents a user's avatar in a way that respects prefers-reduced-motion.
  */
 export const AvatarImage: Component<AvatarProps> = (props) => {
-    const sizeClass = `size-${props.twSize ?? "md"}`;
     return (
         <div
             class={cn(
                 "flex-none rounded-md aspect-square overflow-hidden",
-                sizeClass,
+                props.imgClass,
                 props.class
             )}
         >
             <picture>
                 <source
                     srcset={props.user.avatar_static}
-                    class={sizeClass}
+                    class={props.imgClass}
                     media="(prefers-reduced-motion: reduced)"
                 />
                 <img
                     src={props.user.avatar}
-                    class={sizeClass}
+                    class={props.imgClass}
                     alt={props.alt ?? `Avatar for ${props.user.display_name}`}
                 />
             </picture>

--- a/src/components/user/profile-zone.tsx
+++ b/src/components/user/profile-zone.tsx
@@ -111,7 +111,7 @@ export const ProfileZone: Component<ProfileZoneProps> = (props) => {
             <div class="flex flex-row md:flex-col md:items-center gap-4">
                 <AvatarLink
                     user={props.userInfo}
-                    twSize="24"
+                    imgClass="size-24"
                     class="shadow-md"
                 />
                 <div class="flex flex-col md:items-center">

--- a/src/components/user/profile-zone.tsx
+++ b/src/components/user/profile-zone.tsx
@@ -16,6 +16,7 @@ import {
 import HtmlSandbox from "~/views/htmlsandbox";
 import { useAuthContext } from "~/lib/auth-context";
 import { FaSolidLock } from "solid-icons/fa";
+import { AvatarLink } from "./avatar";
 
 /// Button that shows "Follow"/"Request to Follow"/"Unfollow"/"Cancel Request"
 /// and acts accordingly when clicked
@@ -108,18 +109,11 @@ export const ProfileZone: Component<ProfileZoneProps> = (props) => {
     return (
         <div class="md:w-72 p-8 md:flex-shrink-0 flex gap-4 min-h-max flex-col md:items-center justify-start bg-secondary text-secondary-foreground">
             <div class="flex flex-row md:flex-col md:items-center gap-4">
-                <picture class="aspect-square shadow-md size-24 object-fill">
-                    <source
-                        class="w-full h-full rounded-md"
-                        srcset={props.userInfo.avatar_static}
-                        media="(prefers-reduced-motion)"
-                    />
-                    <img
-                        class="w-full h-full rounded-md"
-                        src={props.userInfo.avatar}
-                        alt={`User avatar for ${props.userInfo.username}`}
-                    />
-                </picture>
+                <AvatarLink
+                    user={props.userInfo}
+                    twSize="24"
+                    class="shadow-md"
+                />
                 <div class="flex flex-col md:items-center">
                     <div class="flex flex-row items-center gap-2">
                         <h2 class="text-xl font-bold">

--- a/src/views/comment.tsx
+++ b/src/views/comment.tsx
@@ -17,6 +17,7 @@ import HtmlSandbox from "./htmlsandbox";
 import { useAuthContext } from "~/lib/auth-context";
 import { Timestamp } from "~/components/post/timestamp";
 import { DateTime } from "luxon";
+import { AvatarLink } from "~/components/user/avatar";
 
 export type CommentProps = {
     status: Status;
@@ -32,15 +33,7 @@ export const CommentPostComponent: Component<CommentProps> = (postData) => {
     return (
         <>
             <div class="flex flex-row items-center flex-wrap border-b">
-                <div class="size-10 flex-none aspect-square">
-                    <A href={userHref} class="aspect-square">
-                        <img
-                            src={status.account.avatar}
-                            class="aspect-square"
-                            alt={`the avatar of ${status.account.acct}`}
-                        />
-                    </A>
-                </div>
+                <AvatarLink user={status.account} twSize="6" />
                 <A href={userHref} class="m-2">
                     {status.account.display_name}
                 </A>

--- a/src/views/comment.tsx
+++ b/src/views/comment.tsx
@@ -33,7 +33,7 @@ export const CommentPostComponent: Component<CommentProps> = (postData) => {
     return (
         <>
             <div class="flex flex-row items-center flex-wrap border-b">
-                <AvatarLink user={status.account} twSize="6" />
+                <AvatarLink user={status.account} imgClass="size-6" />
                 <A href={userHref} class="m-2">
                     {status.account.display_name}
                 </A>

--- a/src/views/facets/notifications.tsx
+++ b/src/views/facets/notifications.tsx
@@ -208,7 +208,7 @@ export const GroupedNotificationComponent: Component<{
                                                 >
                                                     <AvatarLink
                                                         user={n.account!}
-                                                        twSize="6"
+                                                        imgClass="size-6"
                                                         class="inline-block"
                                                     />
                                                 </a>

--- a/src/views/facets/notifications.tsx
+++ b/src/views/facets/notifications.tsx
@@ -152,7 +152,7 @@ export const GroupedNotificationComponent: Component<{
                                 <Show when={firstNotification.account != null}>
                                     <AvatarLink
                                         user={firstNotification.account!}
-                                        twSize="6"
+                                        imgClass="size-6"
                                         class="inline-block underline"
                                     />
                                 </Show>

--- a/src/views/facets/notifications.tsx
+++ b/src/views/facets/notifications.tsx
@@ -25,6 +25,7 @@ import {
 import { AuthProviderProps, useAuthContext } from "~/lib/auth-context";
 import { HtmlPreviewSpan } from "../htmlsandbox";
 import { Timestamp } from "~/components/post/timestamp";
+import { AvatarLink } from "~/components/user/avatar";
 
 type NotificationDayGroups = {
     created_day: DateTime<true> | DateTime<false>;
@@ -148,17 +149,13 @@ export const GroupedNotificationComponent: Component<{
                     <a class="flex flex-wrap w-full p-3 border-2 rounded-xl gap-1 my-2">
                         <Switch>
                             <Match when={notifications.length === 1}>
-                                <a
-                                    href={`/user/${firstNotification.account?.acct}`}
-                                    class="underline"
-                                    title={firstNotification.account?.acct}
-                                >
-                                    <img
-                                        src={firstNotification.account?.avatar}
-                                        alt={`${firstNotification.account?.display_name}`}
-                                        class="aspect-square h-6 inline"
+                                <Show when={firstNotification.account != null}>
+                                    <AvatarLink
+                                        user={firstNotification.account!}
+                                        twSize="6"
+                                        class="inline-block underline"
                                     />
-                                </a>
+                                </Show>
                                 <a
                                     href={`/user/${firstNotification.account?.acct}`}
                                     class="underline"
@@ -209,10 +206,10 @@ export const GroupedNotificationComponent: Component<{
                                                     class="flex"
                                                     title={`${n.account?.acct}`}
                                                 >
-                                                    <img
-                                                        src={n.account?.avatar}
-                                                        alt={`${n.account?.display_name}`}
-                                                        class="aspect-square h-6 inline"
+                                                    <AvatarLink
+                                                        user={n.account!}
+                                                        twSize="6"
+                                                        class="inline-block"
                                                     />
                                                 </a>
                                             </>

--- a/src/views/post.tsx
+++ b/src/views/post.tsx
@@ -6,28 +6,22 @@ import {
     createResource,
     createSignal,
     ErrorBoundary,
-    For,
     JSX,
     Match,
     Resource,
-    Setter,
     Show,
     splitProps,
     Switch,
     type Component,
 } from "solid-js";
-import { tryGetAuthenticatedClient } from "~/App";
 import { AuthProviderProps, useAuthContext } from "~/lib/auth-context";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Flex } from "~/components/ui/flex";
-import { Grid, Col } from "~/components/ui/grid";
 import HtmlSandbox from "./htmlsandbox";
 import {
     ContextMenu,
     ContextMenuContent,
     ContextMenuItem,
-    ContextMenuSeparator,
     ContextMenuTrigger,
 } from "~/components/ui/context-menu";
 import { TextField, TextFieldTextArea } from "~/components/ui/text-field";
@@ -42,6 +36,7 @@ import { ContentGuard } from "~/components/content-guard";
 import { ImageBox } from "~/components/post/image-box";
 import { Timestamp } from "~/components/post/timestamp";
 import { DateTime } from "luxon";
+import { AvatarLink } from "~/components/user/avatar";
 
 export type PostWithSharedProps = {
     status: Status;
@@ -107,11 +102,7 @@ const PostUserBar: Component<{
 
     return (
         <div class="border-b flex flex-row flex-wrap items-center gap-x-2 p-2 flex-auto">
-            <img
-                src={status.account.avatar}
-                class="aspect-square h-8 inline"
-                alt={`the avatar of ${status.account.acct}`}
-            />
+            <AvatarLink user={status.account} twSize="8" class="inline-block" />
             <div class="flex flex-row gap-2 items-center">
                 <A href={userHref} class="whitespace-nowrap">
                     {status.account.display_name}
@@ -215,15 +206,11 @@ const Post: Component<PostProps> = (postData) => {
             class={cn("flex flex-row flex-auto  md:px-8 py-1", postData.class)}
         >
             <ErrorBoundary fallback={(err) => err}>
-                <div class="w-16 flex-none hidden md:block">
-                    <A href={userHref} class="m-2 size-16 aspect-square">
-                        <img
-                            src={status().account.avatar}
-                            class="aspect-square"
-                            alt={`the avatar of ${status().account.acct}`}
-                        />
-                    </A>
-                </div>
+                <AvatarLink
+                    user={status().account}
+                    twSize="16"
+                    class="hidden md:block md:m-4"
+                />
                 <Card class="m-1 md:m-4 flex-auto">
                     <PostWithShared
                         status={postData.status}
@@ -279,8 +266,6 @@ const Post: Component<PostProps> = (postData) => {
 
 const StatusPostBlock: Component<StatusPostBlockProps> = (postData) => {
     const status = postData.status;
-
-    const [showRaw, setShowRaw] = createSignal<boolean>(false);
 
     return (
         <>

--- a/src/views/post.tsx
+++ b/src/views/post.tsx
@@ -102,7 +102,11 @@ const PostUserBar: Component<{
 
     return (
         <div class="border-b flex flex-row flex-wrap items-center gap-x-2 p-2 flex-auto">
-            <AvatarLink user={status.account} twSize="8" class="inline-block" />
+            <AvatarLink
+                user={status.account}
+                imgClass="size-8"
+                class="inline-block"
+            />
             <div class="flex flex-row gap-2 items-center">
                 <A href={userHref} class="whitespace-nowrap">
                     {status.account.display_name}
@@ -208,7 +212,7 @@ const Post: Component<PostProps> = (postData) => {
             <ErrorBoundary fallback={(err) => err}>
                 <AvatarLink
                     user={status().account}
-                    twSize="16"
+                    imgClass="size-16"
                     class="hidden md:block md:m-4"
                 />
                 <Card class="m-1 md:m-4 flex-auto">


### PR DESCRIPTION
This provides two components: AvatarImage and AvatarLink. AvatarImage provides the user's avatar as a picture that disables animation if the user requests reduced motion. AvatarLink provides a simple wrapper with an `<A>` link to the user's profile.

AvatarLink isn't strictly needed, but it's expected that an avatar is a link in enough places that a shorthand of sorts seemed useful.