### PR TITLE
make images render in posts

### DIFF
--- a/src/components/post/image-box.tsx
+++ b/src/components/post/image-box.tsx
@@ -11,7 +11,7 @@ interface ImageAttachmentProps {
 }
 
 const ImageAttachment: Component<ImageAttachmentProps> = (props) => {
-    let src = props.attachment.text_url;
+    let src = props.attachment.preview_url;
     let srcset = "";
     let sizes = "";
     if (props.attachment.preview_url && props.attachment.meta) {
@@ -19,7 +19,7 @@ const ImageAttachment: Component<ImageAttachmentProps> = (props) => {
         const small_width = props.attachment.meta.small?.width ?? 400;
         srcset += `${props.attachment.preview_url} ${small_width}px `;
         const orig_width = props.attachment.meta.original?.width;
-        srcset += `${props.attachment.text_url} ${orig_width}px `;
+        srcset += `${props.attachment.url} ${orig_width}px `;
         sizes += `(max-width: ${small_width}px) ${small_width}px, ${orig_width}px`;
     }
 

--- a/src/components/post/image-lightbox.tsx
+++ b/src/components/post/image-lightbox.tsx
@@ -19,7 +19,7 @@ const InnerImage: Component<{ image: Attachment }> = (props) => {
     return (
         <img
             class="max-h-[calc(100vh-8rem)] object-scale-down mb-2 mx-auto pointer-events-auto"
-            src={props.image.text_url!}
+            src={props.image.url!}
             alt={props.image.description!}
         />
     );


### PR DESCRIPTION
looks like `text_url` has been deprecated for a while, swapping it for `url` and `preview_url` depending on context seems to do the right thing :)

edit: thanks to liffy making me check, this doesn't give us images in comments, but i figure that's a separate task anyway?