### PR TITLE
Generic PostFeed component

### DIFF
--- a/src/components/post/feed/feed-context.tsx
+++ b/src/components/post/feed/feed-context.tsx
@@ -1,0 +1,20 @@
+import { Status } from "megalodon/lib/src/entities/status";
+import { createContext, Resource, ResourceActions, useContext } from "solid-js";
+
+export interface FeedContextValue {
+    postList: Resource<Status[] | undefined>;
+    postListActions: ResourceActions<Status[] | undefined>;
+    resetFeed: () => void;
+}
+
+export const FeedContext = createContext<FeedContextValue>();
+
+export function useFeedContext() {
+    const context = useContext(FeedContext);
+    if (context == undefined) {
+        throw new Error(
+            "useFeedContext must be used within a <PostFeed> component"
+        );
+    }
+    return context;
+}

--- a/src/components/post/feed/index.tsx
+++ b/src/components/post/feed/index.tsx
@@ -5,6 +5,7 @@ import {
     Component,
     createEffect,
     createResource,
+    createSignal,
     ErrorBoundary,
     For,
 } from "solid-js";
@@ -31,6 +32,7 @@ type RequestHandler = (
 
 export interface PostFeedProps {
     onRequest: RequestHandler;
+    lastRefresh?: number;
 }
 
 async function fetchPostList(
@@ -73,6 +75,17 @@ export const PostFeed: Component<PostFeedProps> = (props) => {
         },
         (options) => fetchPostList(props.onRequest, authContext, options)
     );
+
+    const [lastRefresh, setLastRefresh] = createSignal(
+        props.lastRefresh ?? Date.now()
+    );
+
+    createEffect(() => {
+        if (props.lastRefresh != null && props.lastRefresh != lastRefresh()) {
+            console.log("[PostFeed] refresh requested");
+            listActions.refetch();
+        }
+    });
 
     const feedContext = {
         postList: postList,

--- a/src/components/post/feed/index.tsx
+++ b/src/components/post/feed/index.tsx
@@ -1,0 +1,126 @@
+import { useSearchParams } from "@solidjs/router";
+import { Entity, Response } from "megalodon";
+import { Status } from "megalodon/lib/src/entities/status";
+import {
+    Component,
+    createEffect,
+    createResource,
+    ErrorBoundary,
+    For,
+} from "solid-js";
+import { AuthProviderProps, useAuthContext } from "~/lib/auth-context";
+import Post from "..";
+import { PageNav } from "~/components/ui/page-footer";
+import { Button } from "~/components/ui/button";
+import { FeedContext } from "./feed-context";
+
+interface GetTimelineOptionsApi {
+    local?: boolean;
+    limit?: number;
+    max_id?: string;
+    since_id?: string;
+    min_id?: string;
+}
+
+interface GetTimelineOptions extends GetTimelineOptionsApi {}
+
+type RequestHandler = (
+    authContext: AuthProviderProps,
+    timelineOptions: GetTimelineOptions
+) => Promise<Response<Array<Status>>> | undefined;
+
+export interface PostFeedProps {
+    onRequest: RequestHandler;
+}
+
+async function fetchPostList(
+    handler: RequestHandler,
+    authContext: AuthProviderProps,
+    timelineOptions: GetTimelineOptions
+) {
+    console.log(
+        `fetching posts with options: ${JSON.stringify(timelineOptions)}`
+    );
+
+    const posts: Status[] = [];
+    const result = await handler(authContext, timelineOptions);
+    if (result == undefined) {
+        console.log("Got no response from handler");
+        return;
+    }
+
+    if (result.status !== 200) {
+        throw new Error(`Failed to get timeline: ${result.statusText}`);
+    }
+    for (const post of result.data) {
+        if (post.in_reply_to_id === null) {
+            posts.push(post);
+        }
+    }
+    return posts;
+}
+
+export const PostFeed: Component<PostFeedProps> = (props) => {
+    const authContext = useAuthContext();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [postList, listActions] = createResource(
+        () => {
+            return {
+                local: false,
+                limit: 25,
+                max_id: searchParams.after,
+            };
+        },
+        (options) => fetchPostList(props.onRequest, authContext, options)
+    );
+
+    const feedContext = {
+        postList: postList,
+        postListActions: listActions,
+        resetFeed: () => {
+            setSearchParams({ after: undefined }, { scroll: true });
+            listActions.refetch();
+        },
+    };
+
+    return (
+        <FeedContext.Provider value={feedContext}>
+            <div>
+                <ErrorBoundary fallback={<div>Failed to load posts.</div>}>
+                    <For each={postList()}>
+                        {(status, index) => (
+                            <Post status={status} fetchShareParent={false} />
+                        )}
+                    </For>
+                    <PageNav>
+                        {/* TODO: figure out how to go back reliably */}
+                        <Button
+                            classList={{
+                                invisible: searchParams.after == undefined,
+                            }}
+                            disabled={true}
+                        >
+                            Back
+                        </Button>
+                        <Button
+                            onClick={() => {
+                                const p = postList();
+                                if (p != null) {
+                                    const last = p[p.length - 1];
+                                    if (last != null) {
+                                        setSearchParams(
+                                            { after: last.id },
+                                            { scroll: true }
+                                        );
+                                    }
+                                }
+                            }}
+                        >
+                            Next
+                        </Button>
+                    </PageNav>
+                </ErrorBoundary>
+            </div>
+        </FeedContext.Provider>
+    );
+};

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -16,8 +16,8 @@ import {
 } from "solid-js";
 import { AuthProviderProps, useAuthContext } from "~/lib/auth-context";
 import { Button } from "~/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import HtmlSandbox from "./htmlsandbox";
+import { Card, CardContent } from "~/components/ui/card";
+import HtmlSandbox from "../../views/htmlsandbox";
 import {
     ContextMenu,
     ContextMenuContent,
@@ -156,7 +156,7 @@ const PostBody: Component<PostBodyProps> = (props) => {
 
 const PostFooter: Component<{ children: JSX.Element }> = (props) => {
     return (
-        <div class="m-2 flex flex-row flex-wrap items-center justify-stretch">
+        <div class="my-1 mx-2 flex flex-row flex-wrap items-center justify-stretch">
             {props.children}
         </div>
     );
@@ -206,9 +206,7 @@ const Post: Component<PostProps> = (postData) => {
     const postHref = `/post/${status().id}`;
 
     return (
-        <div
-            class={cn("flex flex-row flex-auto  md:px-8 py-1", postData.class)}
-        >
+        <div class={cn("flex flex-row flex-auto md:px-8 py-1", postData.class)}>
             <ErrorBoundary fallback={(err) => err}>
                 <AvatarLink
                     user={status().account}
@@ -238,7 +236,7 @@ const Post: Component<PostProps> = (postData) => {
                         </ContextMenu>
                         <Button
                             variant="ghost"
-                            class="hover:bg-transparent py-0"
+                            class="hover:bg-transparent p-0"
                             aria-label="Like Post"
                             onClick={async () => {
                                 if (!authContext.authState.signedIn) {

--- a/src/components/ui/page-footer.tsx
+++ b/src/components/ui/page-footer.tsx
@@ -1,0 +1,10 @@
+import { Component, JSX, mergeProps } from "solid-js";
+import { Button } from "./button";
+
+export const PageNav: Component<{ children: JSX.Element }> = (props) => {
+    return (
+        <div class="flex flex-row w-full justify-between p-1 md:p-12">
+            {props.children}
+        </div>
+    );
+};

--- a/src/views/feed.tsx
+++ b/src/views/feed.tsx
@@ -28,7 +28,15 @@ export interface SubmitFeedState {
 }
 
 const Feed: Component = () => {
-    // const location = useLocation<SubmitFeedState>();
+    const location = useLocation<SubmitFeedState>();
+
+    const [lastRefresh, setLastRefresh] = createSignal(Date.now());
+
+    createEffect(() => {
+        if (location.state?.new_id != null) {
+            setLastRefresh(Date.now());
+        }
+    });
 
     return (
         <PostFeed
@@ -41,6 +49,7 @@ const Feed: Component = () => {
                     authContext.authState.signedIn.authenticatedClient;
                 return client.getHomeTimeline(timelineOptions);
             }}
+            lastRefresh={lastRefresh()}
         />
     );
 };

--- a/src/views/feed.tsx
+++ b/src/views/feed.tsx
@@ -19,104 +19,29 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Flex } from "~/components/ui/flex";
 import { Grid, Col } from "~/components/ui/grid";
-import Post from "./post";
+import Post from "~/components/post";
 import { Status } from "megalodon/lib/src/entities/status";
+import { PostFeed } from "~/components/post/feed";
 
 export interface SubmitFeedState {
     new_id: string;
 }
 
-interface GetTimelineOptionsApi {
-    local?: boolean;
-    limit?: number;
-    max_id?: string;
-    since_id?: string;
-    min_id?: string;
-}
-
-interface GetTimelineOptions extends GetTimelineOptionsApi {}
-
-const fetchPostList = async (
-    authContext: AuthProviderProps,
-    timelineOptions: GetTimelineOptions
-) => {
-    console.log(
-        `fetching posts with options: ${JSON.stringify(timelineOptions)}`
-    );
-    if (!authContext.authState.signedIn) {
-        return;
-    }
-
-    const client = authContext.authState.signedIn.authenticatedClient;
-    const posts: Status[] = [];
-    const result = await client.getHomeTimeline(timelineOptions);
-    if (result.status !== 200) {
-        throw new Error(`Failed to get timeline: ${result.statusText}`);
-    }
-    for (const post of result.data) {
-        if (post.in_reply_to_id === null) {
-            posts.push(post);
-        }
-    }
-    return posts;
-};
-
 const Feed: Component = () => {
-    const authContext = useAuthContext();
-    const location = useLocation<SubmitFeedState>();
-    const [searchParams, setSearchParams] = useSearchParams();
-    const [postList, { mutate, refetch }] = createResource(
-        () => {
-            return {
-                local: false,
-                limit: 25,
-                max_id: searchParams.after,
-            };
-        }, // If this returns null or undefined, resource won't be loaded.
-        (options) => fetchPostList(authContext, options)
-    );
-    createEffect(() => {
-        if (location.state?.new_id) {
-            console.log("new_id updated! updating search params");
-            setSearchParams({ after: null }, { scroll: true });
-            refetch();
-        }
-    });
+    // const location = useLocation<SubmitFeedState>();
 
     return (
-        <>
-            <div>
-                <ErrorBoundary fallback={<div>ouch!</div>}>
-                    <For each={postList()}>
-                        {(status, index) => (
-                            <Post status={status} fetchShareParent={false} />
-                        )}
-                    </For>
-                </ErrorBoundary>
-            </div>
-            <div>
-                <div class="flex flex-row w-100 m-8">
-                    <div class="grow"></div>
-                    <Button
-                        class="grow-0"
-                        onClick={() => {
-                            let p = postList();
-                            if (p !== undefined) {
-                                let last = p[p.length - 1];
-                                if (last !== undefined) {
-                                    setSearchParams(
-                                        { after: last.id },
-                                        { scroll: true }
-                                    );
-                                }
-                            }
-                        }}
-                    >
-                        Next
-                    </Button>
-                </div>
-            </div>
-        </>
+        <PostFeed
+            onRequest={(authContext, timelineOptions) => {
+                if (!authContext.authState.signedIn) {
+                    return;
+                }
+
+                const client =
+                    authContext.authState.signedIn.authenticatedClient;
+                return client.getHomeTimeline(timelineOptions);
+            }}
+        />
     );
 };
 

--- a/src/views/postpage.tsx
+++ b/src/views/postpage.tsx
@@ -17,7 +17,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Flex } from "~/components/ui/flex";
 import { Grid, Col } from "~/components/ui/grid";
-import Post, { PostWithShared } from "./post";
+import Post, { PostWithShared } from "~/components/post";
 import { Status } from "megalodon/lib/src/entities/status";
 import { DiGraph, VertexDefinition } from "digraph-js";
 import { CommentPostComponent } from "./comment";

--- a/src/views/userprofile.tsx
+++ b/src/views/userprofile.tsx
@@ -1,19 +1,6 @@
 import { A, useParams } from "@solidjs/router";
 import { Entity } from "megalodon";
-import {
-    createResource,
-    createSignal,
-    For,
-    Setter,
-    Show,
-    type Component,
-} from "solid-js";
-import { tryGetAuthenticatedClient } from "~/App";
-import { Button } from "~/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
-import { Flex } from "~/components/ui/flex";
-import { Grid, Col } from "~/components/ui/grid";
-import Post from "./post";
+import { createResource, createSignal, Show, type Component } from "solid-js";
 import { AuthProviderProps, useAuthContext } from "~/lib/auth-context";
 import { ProfileZone } from "~/components/user/profile-zone";
 


### PR DESCRIPTION
This PR depends on #14, mainly because I gave up dealing with merge conflicts on the post components.

This creates a PostFeed component, responsible for the actual feed that appears as the timeline, or will appear on profile pages.

For the most part it's working, but two caveats:

- [x] Without a direct way to reset the feed, we're back to the broken state where posting while on `/feed` doesn't update the home timeline. Current plan is to use the FeedContext to create some kind of "reloader" component, but not sure if this is the best idea.

- [ ] Back button. Maybe I'm overthinking it, but is there a reliable way to determine what the "first" page is in a stateless way? My first thought is Load last 25 -> Load 25 before that -> If 0 posts, we're on the first page. but that's really noisy, and would lead to weird situations where the new first page might show an oddly small number of posts.