### PR TITLE
Custom emoji support via rehype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,17 @@
                 "@kobalte/core": "^0.13.6",
                 "@solid-primitives/storage": "^4.2.1",
                 "@solidjs/router": "^0.14.5",
+                "@types/hast": "^3.0.4",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.1.1",
                 "digraph-js": "^2.2.3",
                 "get-urls": "^12.1.0",
+                "hast-util-find-and-replace": "^5.0.1",
+                "hast-util-sanitize": "^5.0.1",
+                "hastscript": "^9.0.0",
                 "luxon": "^3.5.0",
                 "megalodon": "^10.0.3",
+                "rehype": "^13.0.2",
                 "rehype-parse": "^9.0.1",
                 "rehype-sanitize": "^6.0.0",
                 "rehype-stringify": "^10.0.1",
@@ -26,6 +31,7 @@
                 "tailwind-merge": "^2.5.2",
                 "tailwindcss-animate": "^1.0.7",
                 "unified": "^11.0.5",
+                "unist-util-visit": "^5.0.0",
                 "url-regex-safe": "^4.0.0"
             },
             "devDependencies": {
@@ -2364,6 +2370,32 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hast-util-find-and-replace": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-find-and-replace/-/hast-util-find-and-replace-5.0.1.tgz",
+            "integrity": "sha512-S12fTskO3Hf2IGCBWXs1UcXT8GEJ3jmvmPZJctkRwfl3a8jnGi8aFYT8kd2zcEH+VE0qcGgKF0ewt5BPAsfIhw==",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-find-and-replace/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/hast-util-from-html": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
@@ -2394,6 +2426,34 @@
                 "vfile": "^6.0.0",
                 "vfile-location": "^5.0.0",
                 "web-namespaces": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-from-parse5/node_modules/hastscript": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+            "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^6.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-is-element": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2461,9 +2521,9 @@
             }
         },
         "node_modules/hastscript": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
-            "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
+            "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
             "dependencies": {
                 "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
@@ -3267,6 +3327,21 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/rehype": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+            "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "rehype-parse": "^9.0.0",
+                "rehype-stringify": "^10.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/rehype-parse": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "license": "MIT",
     "devDependencies": {
+        "@types/hast": "^3.0.4",
         "@types/luxon": "^3.4.2",
         "@types/node": "^22.5.5",
         "@types/url-regex-safe": "^1.0.2",
@@ -31,6 +32,8 @@
         "clsx": "^2.1.1",
         "digraph-js": "^2.2.3",
         "get-urls": "^12.1.0",
+        "hast-util-find-and-replace": "^5.0.1",
+        "hastscript": "^9.0.0",
         "luxon": "^3.5.0",
         "megalodon": "^10.0.3",
         "rehype-parse": "^9.0.1",

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -152,7 +152,10 @@ const PostBody: Component<PostBodyProps> = (props) => {
         <CardContent class={cn("p-3", props.class)} {...rest}>
             <ContentGuard warnings={props.status.spoiler_text}>
                 <ImageBox attachments={props.status.media_attachments} />
-                <HtmlSandbox html={props.status.content} />
+                <HtmlSandbox
+                    html={props.status.content}
+                    emoji={props.status.emojis}
+                />
             </ContentGuard>
         </CardContent>
     );

--- a/src/components/user/profile-zone.tsx
+++ b/src/components/user/profile-zone.tsx
@@ -13,10 +13,7 @@ import {
     Show,
     Switch,
 } from "solid-js";
-import HtmlSandbox, {
-    HtmlPreviewSpan,
-    HtmlSandboxSpan,
-} from "~/views/htmlsandbox";
+import HtmlSandbox, { HtmlSandboxSpan } from "~/views/htmlsandbox";
 import { useAuthContext } from "~/lib/auth-context";
 import { FaSolidLock } from "solid-icons/fa";
 import { AvatarLink } from "./avatar";

--- a/src/components/user/profile-zone.tsx
+++ b/src/components/user/profile-zone.tsx
@@ -13,7 +13,10 @@ import {
     Show,
     Switch,
 } from "solid-js";
-import HtmlSandbox from "~/views/htmlsandbox";
+import HtmlSandbox, {
+    HtmlPreviewSpan,
+    HtmlSandboxSpan,
+} from "~/views/htmlsandbox";
 import { useAuthContext } from "~/lib/auth-context";
 import { FaSolidLock } from "solid-icons/fa";
 import { AvatarLink } from "./avatar";
@@ -82,11 +85,16 @@ const FollowButton: Component<{ account: Entity.Account }> = (props) => {
     );
 };
 
-const ProfileField: Component<{ field: Entity.Field }> = (props) => {
+const ProfileField: Component<{
+    field: Entity.Field;
+    emoji?: Entity.Emoji[];
+}> = (props) => {
     return (
         <div class="mb-2">
-            <div class="font-bold text-sm">{props.field.name}</div>
-            <HtmlSandbox html={props.field.value} />
+            <div class="font-bold text-sm">
+                <HtmlSandboxSpan html={props.field.name} emoji={props.emoji} />
+            </div>
+            <HtmlSandboxSpan html={props.field.value} emoji={props.emoji} />
         </div>
     );
 };
@@ -117,7 +125,10 @@ export const ProfileZone: Component<ProfileZoneProps> = (props) => {
                 <div class="flex flex-col md:items-center">
                     <div class="flex flex-row items-center gap-2">
                         <h2 class="text-xl font-bold">
-                            {props.userInfo.display_name}
+                            <HtmlSandboxSpan
+                                html={props.userInfo.display_name}
+                                emoji={props.userInfo.emojis}
+                            />
                         </h2>
                         <Show when={props.userInfo.locked}>
                             <FaSolidLock
@@ -142,12 +153,20 @@ export const ProfileZone: Component<ProfileZoneProps> = (props) => {
             >
                 <FollowButton account={props.userInfo} />
             </Show>
-            <HtmlSandbox html={props.userInfo.note} />
+            <HtmlSandbox
+                html={props.userInfo.note}
+                emoji={props.userInfo.emojis}
+            />
             <Show when={props.userInfo.fields.length > 0}>
                 <hr class="border-accent-foreground w-full" />
                 <div class="flex flex-col justify-start w-full">
                     <For each={props.userInfo.fields}>
-                        {(field, index) => <ProfileField field={field} />}
+                        {(field, index) => (
+                            <ProfileField
+                                field={field}
+                                emoji={props.userInfo.emojis}
+                            />
+                        )}
                     </For>
                 </div>
             </Show>

--- a/src/lib/rehype-emoji.ts
+++ b/src/lib/rehype-emoji.ts
@@ -29,7 +29,6 @@ export default function rehypeEmoji(options: RehypeEmojiOptions) {
     };
 
     return function (tree: Root) {
-        console.log("it's parsing time");
         findAndReplace(tree, [[/:([\p{Letter}\d_]+):/gu, replacer]]);
     };
 }

--- a/src/lib/rehype-emoji.ts
+++ b/src/lib/rehype-emoji.ts
@@ -1,0 +1,35 @@
+import { Root } from "hast";
+import { findAndReplace } from "hast-util-find-and-replace";
+import { Entity } from "megalodon";
+import { h } from "hastscript";
+
+export interface RehypeEmojiOptions {
+    emoji_defs?: Entity.Emoji[];
+}
+
+/**
+ * Plugin for rehype to provide custom emoji via the Mastodon API.
+ */
+export default function rehypeEmoji(options: RehypeEmojiOptions) {
+    // Create a map of emoji shortcodes for (hopefully) speed reasons
+    const emojiMap = new Map(
+        options.emoji_defs?.map((em) => [em.shortcode, em])
+    );
+
+    const replacer = ($0: string, $1: string) => {
+        if (emojiMap.has($1)) {
+            const emoji = emojiMap.get($1)!;
+            const static_source = h('source', { class: 'h-full mx-auto', srcset: emoji.static_url, media: '(prefers-reduced-motion: reduced)' });
+            const default_img = h('img', { class: 'h-full mx-auto', src: emoji.url, loading: "lazy", alt: emoji.shortcode });
+            return h('picture', { class: 'inline-block h-[1.2em] aspect-square object-contain align-bottom align-center' }, static_source, default_img);
+        } else {
+            // Not a custom emoji we know about, ignore
+            return $0;
+        }
+    };
+
+    return function (tree: Root) {
+        console.log("it's parsing time");
+        findAndReplace(tree, [[/:([\p{Letter}\d_]+):/gu, replacer]]);
+    };
+}

--- a/src/views/comment.tsx
+++ b/src/views/comment.tsx
@@ -13,7 +13,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Flex } from "~/components/ui/flex";
 import { Grid, Col } from "~/components/ui/grid";
-import HtmlSandbox from "./htmlsandbox";
+import HtmlSandbox, { HtmlSandboxSpan } from "./htmlsandbox";
 import { useAuthContext } from "~/lib/auth-context";
 import { Timestamp } from "~/components/post/timestamp";
 import { DateTime } from "luxon";
@@ -35,7 +35,10 @@ export const CommentPostComponent: Component<CommentProps> = (postData) => {
             <div class="flex flex-row items-center flex-wrap border-b">
                 <AvatarLink user={status.account} imgClass="size-6" />
                 <A href={userHref} class="m-2">
-                    {status.account.display_name}
+                    <HtmlSandboxSpan
+                        html={status.account.display_name}
+                        emoji={status.account.emojis}
+                    />
                 </A>
                 <A href={userHref} class="m-1 text-neutral-500 text-sm">
                     {status.account.acct}
@@ -45,7 +48,7 @@ export const CommentPostComponent: Component<CommentProps> = (postData) => {
                 </A>
             </div>
             <div class="md:px-3">
-                <HtmlSandbox html={status.content} />
+                <HtmlSandbox html={status.content} emoji={status.emojis} />
             </div>
         </>
     );

--- a/src/views/facets/notifications.tsx
+++ b/src/views/facets/notifications.tsx
@@ -101,7 +101,7 @@ export const SingleLinePostPreviewLink: Component<{
                 <Match when={props.status !== undefined}>
                     <a
                         href={`/post/${props.status?.id}`}
-                        class="underline flex flex-1 overflow-hidden"
+                        class="underline flex flex-1 truncate min-w-16"
                     >
                         <HtmlSandboxSpan
                             class="truncate"

--- a/src/views/facets/notifications.tsx
+++ b/src/views/facets/notifications.tsx
@@ -23,7 +23,7 @@ import {
     ContextMenuTrigger,
 } from "~/components/ui/context-menu";
 import { AuthProviderProps, useAuthContext } from "~/lib/auth-context";
-import { HtmlPreviewSpan } from "../htmlsandbox";
+import { HtmlSandboxSpan } from "../htmlsandbox";
 import { Timestamp } from "~/components/post/timestamp";
 import { AvatarLink } from "~/components/user/avatar";
 
@@ -101,11 +101,12 @@ export const SingleLinePostPreviewLink: Component<{
                 <Match when={props.status !== undefined}>
                     <a
                         href={`/post/${props.status?.id}`}
-                        class="underline flex overflow-hidden text-ellipsis"
+                        class="underline flex flex-1 overflow-hidden"
                     >
-                        <HtmlPreviewSpan
+                        <HtmlSandboxSpan
+                            class="truncate"
                             html={props.status!.content}
-                            numChars={80}
+                            emoji={props.status!.emojis}
                         />
                     </a>
                 </Match>

--- a/src/views/htmlsandbox.tsx
+++ b/src/views/htmlsandbox.tsx
@@ -60,7 +60,9 @@ const HtmlSandbox: Component<HtmlSandboxProps> = (props) => {
     */
 };
 
-export interface StrictHtmlSandboxProps extends HtmlSandboxProps {}
+export interface StrictHtmlSandboxProps extends HtmlSandboxProps {
+    class?: string;
+}
 
 /**
  * Component similar to {@link HtmlSandbox}, but provides a span.
@@ -84,31 +86,13 @@ export const HtmlSandboxSpan: Component<StrictHtmlSandboxProps> = (props) => {
     return (
         <Switch>
             <Match when={sanitizedHtml.state === "ready"}>
-                <span innerHTML={sanitizedHtml()} />
+                <span innerHTML={sanitizedHtml()} class={props.class} />
             </Match>
             <Match when={sanitizedHtml.loading}>
                 <span>sanitizing html...</span>
             </Match>
         </Switch>
     );
-};
-
-export const HtmlPreviewSpan: Component<HtmlPreviewSpanProps> = (props) => {
-    const previewParser = unified()
-        .use(rehypeParse, { fragment: true })
-        .use(rehypeSanitize, { ...defaultSchema, tagNames: [] }) // Replaces all tags with their contents, since we allow no tag names.
-        .use(rehypeStringify);
-
-    const [sanitizedHtml] = createResource(props.html, async (fragment) => {
-        const vfile = await previewParser.process(fragment);
-        const previewstr = String(vfile);
-        if (previewstr.length > props.numChars) {
-            return previewstr.substring(0, props.numChars) + "...";
-        }
-        return previewstr;
-    });
-
-    return <span>{sanitizedHtml()}</span>;
 };
 
 export default HtmlSandbox;

--- a/src/views/htmlsandbox.tsx
+++ b/src/views/htmlsandbox.tsx
@@ -1,11 +1,14 @@
+import { Entity } from "megalodon";
 import rehypeParse from "rehype-parse";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeStringify from "rehype-stringify";
 import { createResource, JSX, Match, Switch, type Component } from "solid-js";
 import { unified } from "unified";
+import rehypeEmoji from "~/lib/rehype-emoji";
 
 export type HtmlSandboxProps = {
     html: string;
+    emoji?: Entity.Emoji[];
 };
 
 export interface HtmlPreviewSpanProps
@@ -14,19 +17,18 @@ export interface HtmlPreviewSpanProps
     numChars: number;
 }
 
-const rehypeParser = await unified()
-    .use(rehypeParse, { fragment: true })
-    .use(rehypeSanitize)
-    .use(rehypeStringify);
-
-const previewParser = await unified()
-    .use(rehypeParse, { fragment: true })
-    .use(rehypeSanitize, { ...defaultSchema, tagNames: [] }) // Replaces all tags with their contents, since we allow no tag names.
-    .use(rehypeStringify);
-
+/**
+ * Component for rendering arbitrary HTML (e.g. post content) more safely.
+ */
 const HtmlSandbox: Component<HtmlSandboxProps> = (props) => {
+    const rehypeParser = unified()
+        .use(rehypeParse, { fragment: true })
+        .use(rehypeSanitize)
+        .use(rehypeEmoji, { emoji_defs: props.emoji })
+        .use(rehypeStringify);
+
     const [sanitizedHtml] = createResource(props.html, async (fragment) => {
-        const vfile = await rehypeParser.process(fragment);
+        const vfile = await rehypeParser.process(props.html);
         return String(vfile);
     });
 
@@ -58,7 +60,45 @@ const HtmlSandbox: Component<HtmlSandboxProps> = (props) => {
     */
 };
 
+export interface StrictHtmlSandboxProps extends HtmlSandboxProps {}
+
+/**
+ * Component similar to {@link HtmlSandbox}, but provides a span.
+ *
+ * Note that all tags are sanitized, but emoji are processed. This component is
+ * primarily intended for elements with basic HTML and emoji capability, such as
+ * in a user's profile.
+ */
+export const HtmlSandboxSpan: Component<StrictHtmlSandboxProps> = (props) => {
+    const rehypeParser = unified()
+        .use(rehypeParse, { fragment: true })
+        .use(rehypeSanitize, { ...defaultSchema, tagNames: [] })
+        .use(rehypeEmoji, { emoji_defs: props.emoji })
+        .use(rehypeStringify);
+
+    const [sanitizedHtml] = createResource(props.html, async (fragment) => {
+        const vfile = await rehypeParser.process(props.html);
+        return String(vfile);
+    });
+
+    return (
+        <Switch>
+            <Match when={sanitizedHtml.state === "ready"}>
+                <span innerHTML={sanitizedHtml()} />
+            </Match>
+            <Match when={sanitizedHtml.loading}>
+                <span>sanitizing html...</span>
+            </Match>
+        </Switch>
+    );
+};
+
 export const HtmlPreviewSpan: Component<HtmlPreviewSpanProps> = (props) => {
+    const previewParser = unified()
+        .use(rehypeParse, { fragment: true })
+        .use(rehypeSanitize, { ...defaultSchema, tagNames: [] }) // Replaces all tags with their contents, since we allow no tag names.
+        .use(rehypeStringify);
+
     const [sanitizedHtml] = createResource(props.html, async (fragment) => {
         const vfile = await previewParser.process(fragment);
         const previewstr = String(vfile);


### PR DESCRIPTION
This provides custom emoji support in posts, comments, and user profiles by way of a rehype plugin that converts emoji shortcodes into `<picture>`s.

I'm sure I've missed a few places-- there's lots of places a custom emoji can show up! And I'll admit I don't know how heavy (or light??) a rehype processor can be, but this felt safer than doing `string.replace`.