### PR TITLE
add 'shared your post' label in notifications feed (for glitchsoc at least)

### DIFF
--- a/src/views/facets/notifications.tsx
+++ b/src/views/facets/notifications.tsx
@@ -136,6 +136,9 @@ export const GroupedNotificationComponent: Component<{
         case "mention":
             typeLabel = "mentioned you";
             break;
+        case "reblog":
+            typeLabel = "shared your post";
+            break;
         default:
             break;
     }


### PR DESCRIPTION
As before, only tested with a glitchsoc instance — no idea if gts/akkoma/misskey/etc report it differently, but as far as I can see this shouldn't *break* anything at least. Previously it was just displaying the raw group type 'reblog' instead of the specific label, so I imagine if other platforms *do* report it differently they'll just use that fallback path anyway.