### PR TITLE
prevent severals icons overflowing past the notification bounds

### DIFF
--- a/src/views/facets/notifications.tsx
+++ b/src/views/facets/notifications.tsx
@@ -200,7 +200,7 @@ export const GroupedNotificationComponent: Component<{
                                         />
                                     </Match>
                                 </Switch>
-                                <div class="w-full flex flex-row gap-1">
+                                <div class="w-full flex flex-row gap-1 overflow-hidden">
                                     <For each={notifications}>
                                         {(n, i) => (
                                             <>


### PR DESCRIPTION
The joys of being popular online.

Before:
<img width="390" alt="Screenshot 2024-10-09 at 20 18 21" src="https://github.com/user-attachments/assets/6bb8acca-91b2-4016-8898-b51650b5e985">

After:
<img width="390" alt="Screenshot 2024-10-09 at 20 18 30" src="https://github.com/user-attachments/assets/3d2f59dc-f7e4-4f39-9dce-541cc4a0cb28">
