### PR TITLE
make display-names render in bold, like cohost

### DIFF
--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -112,7 +112,7 @@ const PostUserBar: Component<{
                 class="inline-block"
             />
             <div class="flex flex-row gap-2 items-center">
-                <A href={userHref} class="whitespace-nowrap">
+                <A href={userHref} class="font-bold whitespace-nowrap">
                     {status.account.display_name}
                 </A>
                 <VisibilityIcon class="size-4" value={status.visibility} />
@@ -127,7 +127,7 @@ const PostUserBar: Component<{
                 <FaSolidArrowsRotate />
                 <A
                     href={`/user/${shared!.account.acct}`}
-                    class="whitespace-nowrap"
+                    class="font-bold whitespace-nowrap"
                 >
                     {shared!.account.display_name}
                 </A>

--- a/src/views/comment.tsx
+++ b/src/views/comment.tsx
@@ -34,7 +34,7 @@ export const CommentPostComponent: Component<CommentProps> = (postData) => {
         <>
             <div class="flex flex-row items-center flex-wrap border-b">
                 <AvatarLink user={status.account} imgClass="size-6" />
-                <A href={userHref} class="m-2">
+                <A href={userHref} class="font-bold m-2">
                     <HtmlSandboxSpan
                         html={status.account.display_name}
                         emoji={status.account.emojis}


### PR DESCRIPTION
This one’s purely a “make it feel like cohost” change, but I think it aids legibility a little too.
Applies to both post headers and comments.

Before:
<img width="554" alt="Screenshot 2024-10-09 at 22 56 29" src="https://github.com/user-attachments/assets/40193561-4d16-416a-9b95-815af1058673">

After:
<img width="552" alt="Screenshot 2024-10-09 at 22 56 17" src="https://github.com/user-attachments/assets/00468f1a-db65-4ee9-8db7-a15f60716586">

Just adding `font-bold` in the relevant places, but I'm wondering if it's worth splitting display names out into a reusable component to make it easier to keep the styling consistent everywhere...