### PR TITLE
fix paragraph spacing for exactly-two-paragraphs posts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -124,9 +124,11 @@ a {
     display: inline-block;
     margin-right: 0.7em;
 }
-.post-content p:not(:first-child):not(:last-child) {
-    margin-top: 1em;
-    margin-bottom: 1em;
+.post-content p:not(:first-child) {
+  margin-top: 1em;
+}
+.post-content p:not(:last-child) {
+  margin-bottom: 1em;
 }
 .post-content * {
     overflow-wrap: anywhere;


### PR DESCRIPTION
Just another tiny layout fix — paragraphs were being spaced by putting top-and-bottom margins on every paragraph except the first and last, but that missed the case where there are exactly two paragraphs.

Before:
<img width="530" alt="Screenshot 2024-10-10 at 11 15 19" src="https://github.com/user-attachments/assets/6bc007cd-f36e-4ff9-85e5-1f04ebe918e1">

After:
<img width="525" alt="Screenshot 2024-10-10 at 11 15 26" src="https://github.com/user-attachments/assets/feac874b-15ec-4eea-957e-a2730a873bbd">
