### PR TITLE
full width images + fixed nav menu overlap issue

### DIFF
--- a/src/components/post/image-box.tsx
+++ b/src/components/post/image-box.tsx
@@ -25,6 +25,7 @@ const ImageAttachment: Component<ImageAttachmentProps> = (props) => {
 
     return (
         <button
+            class="w-full"
             onClick={() => {
                 console.log(`Hello! onClick = ${props.onClick}`);
                 props.onClick?.(props.imageIndex);

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -152,10 +152,12 @@ const PostBody: Component<PostBodyProps> = (props) => {
         <CardContent class={cn(props.class)} {...rest}>
             <ContentGuard warnings={props.status.spoiler_text}>
                 <ImageBox attachments={props.status.media_attachments} />
-                <HtmlSandbox
-                    html={props.status.content}
-                    emoji={props.status.emojis}
-                />
+                <div class="p-3">
+                    <HtmlSandbox
+                        html={props.status.content}
+                        emoji={props.status.emojis}
+                    />
+                </div>
             </ContentGuard>
         </CardContent>
     );
@@ -163,7 +165,7 @@ const PostBody: Component<PostBodyProps> = (props) => {
 
 const PostFooter: Component<{ children: JSX.Element }> = (props) => {
     return (
-        <div class="my-1 mx-2 flex flex-row flex-wrap items-center justify-stretch">
+        <div class="my-1 mx-3 flex flex-row flex-wrap items-center justify-stretch">
             {props.children}
         </div>
     );

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -149,7 +149,7 @@ interface PostBodyProps extends JSX.HTMLAttributes<HTMLDivElement> {
 const PostBody: Component<PostBodyProps> = (props) => {
     const [, rest] = splitProps(props, ["status", "class"]);
     return (
-        <CardContent class={cn("p-3", props.class)} {...rest}>
+        <CardContent class={cn(props.class)} {...rest}>
             <ContentGuard warnings={props.status.spoiler_text}>
                 <ImageBox attachments={props.status.media_attachments} />
                 <HtmlSandbox

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ const CardDescription: Component<ComponentProps<"p">> = (props) => {
 
 const CardContent: Component<ComponentProps<"div">> = (props) => {
   const [local, others] = splitProps(props, ["class"])
-  return <div class={cn("p-6 pt-0", local.class)} {...others} />
+  return <div class={cn(local.class)} {...others} />
 }
 
 const CardFooter: Component<ComponentProps<"div">> = (props) => {

--- a/src/views/facetnavigation.tsx
+++ b/src/views/facetnavigation.tsx
@@ -85,7 +85,6 @@ export const FacetNavigationFrame: Component<{ children: JSX.Element }> = (
                     "text-card-foreground": true,
                     "shadow-sm": true,
                     fixed: true,
-                    "z-40": true,
                     hidden: !expandMenuContext.menuOpen(),
                     "md:flex-none": true,
                     "md:mt-4": true,

--- a/src/views/htmlsandbox.tsx
+++ b/src/views/htmlsandbox.tsx
@@ -36,7 +36,7 @@ const HtmlSandbox: Component<HtmlSandboxProps> = (props) => {
         <Switch>
             <Match when={sanitizedHtml.state === "ready"}>
                 <div
-                    class="post-content overflow-auto break-words"
+                    class="post-content p-3 overflow-auto break-words"
                     innerHTML={sanitizedHtml()}
                 />
             </Match>

--- a/src/views/htmlsandbox.tsx
+++ b/src/views/htmlsandbox.tsx
@@ -36,7 +36,7 @@ const HtmlSandbox: Component<HtmlSandboxProps> = (props) => {
         <Switch>
             <Match when={sanitizedHtml.state === "ready"}>
                 <div
-                    class="post-content p-3 overflow-auto break-words"
+                    class="post-content overflow-auto break-words"
                     innerHTML={sanitizedHtml()}
                 />
             </Match>

--- a/src/views/login.tsx
+++ b/src/views/login.tsx
@@ -135,9 +135,9 @@ const LoginView: Component = () => {
                     <CardHeader>
                         <CardTitle>log in</CardTitle>
                     </CardHeader>
-                    <CardContent>
-                        <TextField>
-                            <TextFieldLabel for="instanceUrl">
+                    <CardContent class="p-6">
+                        <TextField class="pb-3">
+                            <TextFieldLabel class="pb-3 block" for="instanceUrl">
                                 Instance URL
                             </TextFieldLabel>
                             <TextFieldInput
@@ -150,7 +150,7 @@ const LoginView: Component = () => {
                                 readOnly={busy()}
                             />
                         </TextField>
-                        <Button onClick={doOAuth} disabled={busy()}>
+                        <Button class="mb-6" onClick={doOAuth} disabled={busy()}>
                             Log in
                             {busy() && (
                                 <span class="animate-spin ml-3">🤔</span>

--- a/src/views/notsignedin.tsx
+++ b/src/views/notsignedin.tsx
@@ -89,7 +89,7 @@ const NotSignedInLandingView: Component = () => {
                     <CardHeader>
                         <CardTitle>pillbug</CardTitle>
                     </CardHeader>
-                    <CardContent>
+                    <CardContent class="p-6 pt-0">
                         <p>
                             pillbug is a cohost-inspired client for GoToSocial
                             and other Mastodon API-compatible ActivityPub
@@ -110,7 +110,7 @@ const NotSignedInLandingView: Component = () => {
                 </Card>
                 <Show when={!authContext.authState.signedIn}>
                     <Card>
-                        <CardContent>
+                        <CardContent class="p-6">
                             <p>you aren't logged in.</p>
                             <p>
                                 <A href="/login" class="underline">
@@ -124,7 +124,7 @@ const NotSignedInLandingView: Component = () => {
                     <CardHeader>
                         <CardTitle>current features</CardTitle>
                     </CardHeader>
-                    <CardContent>
+                    <CardContent class="p-6 pt-0">
                         <p>
                             this is not an exhaustive list of planned features,
                             and it is subject to change. also, a feature may be


### PR DESCRIPTION
My goal was to get the images to display like they did on cohost, so they now take up the full width edge-to-edge. This required moving the padding styles to just the text portion of a post. Also fixed an issue with the side nav menu overlapping the top header bar.