### PR TITLE
Fix share stacking when linking akkoma or mastodon statuses

### DIFF
--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -89,7 +89,7 @@ export function getShareParentUrl(status: Status): string | undefined {
     if (urls === null) {
         return undefined;
     }
-    return urls.find((u) => u.match(/statuses/)) ?? undefined;
+    return urls.find((u) => u.match(/statuses|objects|\d{18}/)) ?? undefined;
 }
 
 const PostUserBar: Component<{


### PR DESCRIPTION
The regex that was used to detect links to other posts was a bit too restrictive (only matched gts posts).

I don't know if 18 digits for mastodon urls is actually correct but, it seems to work somewhat