### PR TITLE
Gracefully fail when a share isn't accessible

### DIFF
--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -284,12 +284,7 @@ const StatusPostBlock: Component<StatusPostBlockProps> = (postData) => {
                         <Match when={postData.shareParent?.loading}>
                             <div>fetching shared post...</div>
                         </Match>
-                        <Match
-                            when={
-                                postData.shareParent !== undefined &&
-                                postData.shareParent() !== undefined
-                            }
-                        >
+                        <Match when={postData.shareParent?.() != null}>
                             <PostWithShared
                                 status={postData.shareParent!() as Status}
                                 showRaw={postData.showRaw}
@@ -301,13 +296,7 @@ const StatusPostBlock: Component<StatusPostBlockProps> = (postData) => {
                             />
                             <PostBody class="border-b" status={status} />
                         </Match>
-                        <Match
-                            when={
-                                postData.shareParent === undefined ||
-                                (postData.shareParent !== undefined &&
-                                    postData.shareParent() === undefined)
-                            }
-                        >
+                        <Match when={postData.shareParent?.() == null}>
                             <PostUserBar status={status} />
                             <PostBody class="border-b" status={status} />
                         </Match>


### PR DESCRIPTION
When accessing a potentially shared post that either isn't actually a share or isn't visible to us, `fetchShareParentPost` returns `null`. This causes such posts to look like this:

![image](https://github.com/user-attachments/assets/31e525d7-710b-4a8f-99ab-ee670cd2026e)

Loose equality is safe to use here, since `null` only matches `null` or `undefined`.

EDIT: I think this is related to #55.