### PR TITLE
move post text over images

### DIFF
--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -167,13 +167,13 @@ const PostBody: Component<PostBodyProps> = (props) => {
     return (
         <CardContent class={cn(props.class)} {...rest}>
             <ContentGuard warnings={props.status.spoiler_text}>
-                <ImageBox attachments={props.status.media_attachments} />
                 <div class="p-3">
                     <HtmlSandbox
                         html={props.status.content}
                         emoji={props.status.emojis}
                     />
                 </div>
+                <ImageBox attachments={props.status.media_attachments} />
             </ContentGuard>
         </CardContent>
     );

--- a/src/views/comment.tsx
+++ b/src/views/comment.tsx
@@ -64,8 +64,8 @@ export const CommentPostComponent: Component<CommentProps> = (postData) => {
             </div>
             <div class="md:px-3 pt-2">
                 <ContentGuard warnings={status.spoiler_text}>
-                    <ImageBox attachments={status.media_attachments} />
                     <HtmlSandbox html={status.content} emoji={status.emojis} />
+                    <ImageBox attachments={status.media_attachments} />
                 </ContentGuard>
             </div>
             <div>


### PR DESCRIPTION
this is less cohost-like but fits better with how other clients post and display images, and how users generally expect them to be.

images-over-text will probably return as a special case later on.