### PR TITLE
Made the post page component keyed to the post ID.

### DIFF
--- a/src/views/postpage.tsx
+++ b/src/views/postpage.tsx
@@ -432,10 +432,12 @@ export const PostPageContext = createContext<PostPageContextValue>();
 const PostPage: Component = () => {
     const params = useParams();
     return (
-        <PostPageForId
-            postId={params.postId}
-            shareEditorMode={false}
-        ></PostPageForId>
+        <Show when={params.postId} keyed>
+            <PostPageForId
+                postId={params.postId}
+                shareEditorMode={false}
+            ></PostPageForId>
+        </Show>
     );
 };
 


### PR DESCRIPTION
I've noticed for a while now that when you're viewing a post, the comments all have their own links to their post page, but clicking on them does nothing, even though the URL _does_ change in the browser bar. While comments can't be shared in pillbug, which would mean that this is mostly irrelevant... they _can_ be shared in other frontends, and when a comment is loaded in pillbug's post view, it only shows its children and its roots, not any other comments on a root post. So, you'd want to click the root post's link to view the other comments... only _nothing happens,_ same as the comments' post links. So I investigated why this was, and found this interesting little post in the SolidJS Router documentation:

> Routes that share the same path match will be treated as the same route. If a force re-render is needed, you can wrap your component in a keyed Show component.

So, I checked the Router on the index page, tracked down the PostPage component, and saw that it wasn't keyed. Changing which post URL you're viewing didn't rerender the page, making all post links _on_ a post page completely unusable.

All this to say that I fixed it. In this PR, you can click a comment's post link to view the page from the comment's perspective, and when you're viewing a comment, you can go to the original post's page. Additionally, while this doesn't _fix_ the weird formatting of comments on shared posts, it does make it much easier to just click into the original post and view the comment tree correctly.